### PR TITLE
Adds transformers and convert to cents transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@
         - [Is Not Null](#is-not-null)
     - [Custom Filters](#Custom-Filters)
     - [Conditional Filters](#Conditional-Filters)
+    - [Transformers](#Transformers)
+        - [Convert To Cents](#convert-to-cents)
 
 ## Describing the Problem
 
@@ -899,3 +901,21 @@ Output:
 |:--------:|:--------------------------:|:----------:|:----:|:----------:|
 | mehrad   | mehrad<i></i>@startapp.id  | mehrad123  |  20  | 2020-09-01 |
 | hossein  | hossein<i></i>@startapp.id | hossein123 |  22  | 2020-11-01 |
+
+### Transformers
+Sometimes the query string you want to present might differ from the way the data is stored in the database. As an example, you may store order subtotals in cents in your database, but in the URL you may want the dollar amount to show. To accomplish this you can use a transformer.
+
+#### Convert To Cents
+Add to your model the fields that are stored in cents
+
+```php
+protected $centsFields = [
+    'subtotal',
+    'total,
+];
+```
+Now you can use the dollar amount in your query and the transformer will convert it to cents.
+
+`orders?subtotal=25` will query the database for subtotals equal to 2500
+
+`orders?subtotal[between][]=125&subtotal[between][]=225` will query the database for subtotals between 12500 and 22500.

--- a/src/Resolvings.php
+++ b/src/Resolvings.php
@@ -12,7 +12,33 @@ trait Resolvings {
 
         $availableFilter = $this->availableFilters[$filterName] ?? $this->availableFilters['default'];
 
+        $values = $this->applyTransformers($filterName, $values);
+
         return app($availableFilter, ['filter' => $filterName, 'values' => $values]);
+    }
+
+    private function applyTransformers($filterName, $values)
+    {
+        $values = $this->convertToCents($filterName, $values);
+
+        return $values;
+    }
+
+    private function convertToCents($filterName, $values)
+    {
+        if (empty($this->centsFields)) {
+            return $values;
+        }
+        
+        if (in_array($filterName, $this->centsFields)) {
+            array_walk_recursive($values, function (&$value) {
+                if (! is_array($value) && is_numeric($value)) {
+                    $value = $value * 100;
+                }
+            });
+        }
+
+        return $values;
     }
 
     private function resolveCustomFilter($filterName, $values)


### PR DESCRIPTION
### Transformers
Sometimes the query string you want to present might differ from the way the data is stored in the database. As an example, you may store order subtotals in cents in your database, but in the URL you may want the dollar amount to show. To accomplish this you can use a transformer.

#### Convert To Cents
Add to your model the fields that are stored in cents

```php
protected $centsFields = [
    'subtotal',
    'total,
];
```
Now you can use the dollar amount in your query and the transformer will convert it to cents.

`orders?subtotal=25` will query the database for subtotals equal to 2500

`orders?subtotal[between][]=125&subtotal[between][]=225` will query the database for subtotals between 12500 and 22500.